### PR TITLE
[update] add get drive number (letter) method

### DIFF
--- a/src/SD/Seeed_SD.cpp
+++ b/src/SD/Seeed_SD.cpp
@@ -35,6 +35,18 @@ namespace fs {
         }
     }
 
+    uint8_t SDFS::getPhysicalDriveNumber() {
+        return _pdrv;
+    }
+
+    String SDFS::getDriveLetter() {
+        if (_pdrv == 0xFF) {
+            // Card not initialized
+            return "";
+        }
+        return String(_pdrv) + ":";
+    }
+
     sdcard_type_t SDFS::cardType() {
         if (_pdrv == 0xFF) {
             return CARD_NONE;

--- a/src/SD/Seeed_SD.h
+++ b/src/SD/Seeed_SD.h
@@ -38,6 +38,9 @@ namespace fs {
         //call this when a card is removed. It will allow you to insert and initialise a new card.
         void end();
 
+        uint8_t getPhysicalDriveNumber();
+        String getDriveLetter();
+
         sdcard_type_t cardType();
         uint64_t cardSize();
         uint64_t totalBytes();

--- a/src/SDMMC/Seeed_SDMMC.cpp
+++ b/src/SDMMC/Seeed_SDMMC.cpp
@@ -45,6 +45,19 @@ namespace fs{
         }
     }
 
+    uint8_t SDMMCFS::getPhysicalDriveNumber() {
+        return _pdrv;
+    }
+
+    String SDMMCFS::getDriveLetter() {
+        if (_pdrv == 0xFF) {
+            // Card not initialized
+            return "";
+        }
+        return String(_pdrv) + ":";
+    }
+
+
     int SDMMCFS::cardType()
     {
         if (_pdrv == 0xFF) {

--- a/src/SDMMC/Seeed_SDMMC.h
+++ b/src/SDMMC/Seeed_SDMMC.h
@@ -24,6 +24,9 @@ namespace fs {
         //call this when a card is removed. It will allow you to insert and initialise a new card.
         void end();
 
+        uint8_t getPhysicalDriveNumber();
+        String getDriveLetter();
+
         int cardType();
         uint64_t cardSize();
         uint64_t totalBytes();


### PR DESCRIPTION
- added getPhysicalDriveNumber( )
- added getDriveLetter( )


In WioTerminal, I found a issue that my program not work correctly when using Flash (SFUD) and SD card at the same time.
The cause is that the drive letter (drive number) of the path is not correctly identified during file processing.

To solve this problem, a drive letter should be added to the beginning of the file path (e.g. "0:/dir/test.txt"), 
but the library did not provide this functionality, so I propose to add it.

I also pullrequested to [Seeed_Arduino_SFUD](https://github.com/Seeed-Studio/Seeed_Arduino_SFUD) repo.